### PR TITLE
2019年晩秋イベ〜2020年1月実装艦の追加（未追加の軽空母・重巡など含む）

### DIFF
--- a/docs/_data/ctypes/amphibious_assault_ship.yml
+++ b/docs/_data/ctypes/amphibious_assault_ship.yml
@@ -1,0 +1,6 @@
+
+- id: ijn-r1
+  name: 陸軍特種船(R1)
+
+- id: ijn-hei
+  name: 特種船丙型

--- a/docs/_data/ctypes/battleship.yml
+++ b/docs/_data/ctypes/battleship.yml
@@ -14,11 +14,11 @@
 - id: yamato
   name: 大和型
 
-# - id: bismarck
-#   name: Bismarck級
+- id: bismarck
+  name: Bismarck級
 
-# - id: vittorioveneto
-#   name: V.Veneto級
+- id: vittorioveneto
+  name: V.Veneto級
 
 - id: colorado
   name: Colorado級
@@ -32,8 +32,8 @@
 - id: nelson
   name: Nelson級
 
-# - id: richelieu
-#   name: Richelieu級
+- id: richelieu
+  name: Richelieu級
 
-# - id: gangut
-#   name: Гангут級
+- id: gangut
+  name: Гангут級

--- a/docs/_data/ctypes/battleship.yml
+++ b/docs/_data/ctypes/battleship.yml
@@ -14,11 +14,11 @@
 - id: yamato
   name: 大和型
 
-- id: bismarck
-  name: Bismarck級
+# - id: bismarck
+#   name: Bismarck級
 
-- id: vittorioveneto
-  name: V.Veneto級
+# - id: vittorioveneto
+#   name: V.Veneto級
 
 - id: colorado
   name: Colorado級
@@ -32,8 +32,8 @@
 - id: nelson
   name: Nelson級
 
-- id: richelieu
-  name: Richelieu級
+# - id: richelieu
+#   name: Richelieu級
 
-- id: gangut
-  name: Гангут級
+# - id: gangut
+#   name: Гангут級

--- a/docs/_data/ctypes/destroyer.yml
+++ b/docs/_data/ctypes/destroyer.yml
@@ -36,19 +36,19 @@
   name: 島風型
 
 - id: z1
-  name: Z1 型
+  name: Z1型（独）
 
 - id: maestrale
-  name: Maestrale 級
+  name: Maestrale級（伊）
 
 - id: johncbutler
-  name: John C.Butler級
+  name: John C.Butler級（米）
 
 - id: fletcher
-  name: Fletcher級
+  name: Fletcher級（米）
 
 - id: hms-j
-  name: J級（英国海軍）
+  name: J級（英）
 
 - id: tashkent
-  name: Ташкент級
+  name: Ташкент級（ソ）

--- a/docs/_data/ctypes/heavy_cruiser.yml
+++ b/docs/_data/ctypes/heavy_cruiser.yml
@@ -1,0 +1,27 @@
+
+- id: furutaka
+  name: 古鷹型
+
+- id: aoba
+  name: 青葉型
+
+- id: myoukou
+  name: 妙高型
+
+- id: takao
+  name: 高雄型
+
+- id: mogami
+  name: 最上型
+
+- id: tone
+  name: 利根型
+
+- id: admiralhipper
+  name: Admiral Hipper級
+
+- id: zara
+  name: Zara級
+
+- id: northampton
+  name: Northampton級

--- a/docs/_data/ctypes/light_carrier.yml
+++ b/docs/_data/ctypes/light_carrier.yml
@@ -1,9 +1,9 @@
 
-# - id: houshou
-#   name: 鳳翔型
-#
-# - id: ryuujou
-#   name: 龍驤型
+- id: houshou
+  name: 鳳翔型
+
+- id: ryuujou
+  name: 龍驤型
 
 - id: ryuuhou
   name: 龍鳳型
@@ -11,14 +11,14 @@
 - id: shouhou
   name: 祥鳳型
 
-# - id: hiyou
-#   name: 飛鷹型
-#
-# - id: chitose-v
-#   name: 千歳型
-#
-# - id: kasugamaru
-#   name: 春日丸型
+- id: hiyou
+  name: 飛鷹型
+
+- id: chitose-v
+  name: 千歳型
+
+- id: kasugamaru
+  name: 春日丸型
 
 - id: taiyou
   name: 大鷹型

--- a/docs/_data/ctypes/light_cruiser.yml
+++ b/docs/_data/ctypes/light_cruiser.yml
@@ -3,13 +3,13 @@
   name: 天龍型
 
 - id: kuma
-  name: 球磨型（雷巡含む）
+  name: 球磨型 #重雷装巡洋艦含む
 
 - id: nagara
   name: 長良型
 
 - id: yuubari
-  name: 夕張型
+  name: 夕張型 #兵装実験軽巡含む
 
 - id: sendai
   name: 川内型
@@ -24,4 +24,20 @@
   name: L.d.S.D.d.Abruzzi級
 
 - id: gotland
-  name: Gotland級
+  name: Gotland級 #軽（航空）巡洋艦含む
+
+- id: deruyter
+  name: De Ruyter級
+
+- id: perth
+  name: Perth級
+
+# 防空巡洋艦
+
+- id: atlanta
+  name: Atlanta級
+
+# 練習巡洋艦
+
+- id: katori
+  name: 香取型

--- a/docs/_data/ctypes/other.yml
+++ b/docs/_data/ctypes/other.yml
@@ -1,0 +1,6 @@
+
+- id: repairship
+  name: 工作艦
+
+- id: submarinetender
+  name: 潜水母艦

--- a/docs/_data/ctypes/seaplane_carrier.yml
+++ b/docs/_data/ctypes/seaplane_carrier.yml
@@ -1,0 +1,15 @@
+
+- id: chitose
+  name: 千歳型
+
+- id: mizuho
+  name: 瑞穂型
+
+- id: nisshin
+  name: 日清型
+
+- id: akitsushima
+  name: 秋津洲型
+
+- id: commandantteste
+  name: C.Teste級

--- a/docs/_data/ctypes/training_cruiser.yml
+++ b/docs/_data/ctypes/training_cruiser.yml
@@ -1,3 +1,0 @@
-
-- id: katori
-  name: 香取型

--- a/docs/_data/ships/admiralhipper.yml
+++ b/docs/_data/ships/admiralhipper.yml
@@ -1,0 +1,3 @@
+
+- id: prinzeugen
+  name: Prinz Eugen / Prinz Eugen改

--- a/docs/_data/ships/akitsushima.yml
+++ b/docs/_data/ships/akitsushima.yml
@@ -1,0 +1,3 @@
+
+- id: akitsushima
+  name: 秋津洲 / 秋津洲改

--- a/docs/_data/ships/aoba.yml
+++ b/docs/_data/ships/aoba.yml
@@ -1,0 +1,15 @@
+
+- id: aoba
+  name: 青葉
+
+- id: aoba_1
+  name: 青葉改
+
+- id: kinugasa
+  name: 衣笠
+
+- id: kinugasa_1
+  name: 衣笠改
+
+- id: kinugasa_2
+  name: 衣笠改二

--- a/docs/_data/ships/chitose-v.yml
+++ b/docs/_data/ships/chitose-v.yml
@@ -1,0 +1,12 @@
+
+- id: chitose
+  name: 千歳航 / 千歳航改
+
+- id: chitose_v2
+  name: 千歳航改二
+
+- id: chiyoda
+  name: 千代田航 /　千代田航改
+
+- id: chiyoda_v2
+  name: 千代田航改二

--- a/docs/_data/ships/chitose.yml
+++ b/docs/_data/ships/chitose.yml
@@ -1,0 +1,12 @@
+
+- id: chitose
+  name: 千歳 / 千歳改
+
+- id: chitose_a
+  name: 千歳甲
+
+- id: chiyoda
+  name: 千代田 / 千代田改
+
+- id: chiyoda_a
+  name: 千代田甲

--- a/docs/_data/ships/commandantteste.yml
+++ b/docs/_data/ships/commandantteste.yml
@@ -1,0 +1,3 @@
+
+- id: commandantteste
+  name: Commandant Teste / Commandant Teste改

--- a/docs/_data/ships/deruyter.yml
+++ b/docs/_data/ships/deruyter.yml
@@ -1,0 +1,3 @@
+
+- id: deruyter
+  name: De Ruyter / De Ruyter改

--- a/docs/_data/ships/etorofu.yml
+++ b/docs/_data/ships/etorofu.yml
@@ -11,6 +11,9 @@
 - id: tsushima
   name: 対馬 / 対馬改
 
+- id: hirato
+  name: 平戸 / 平戸改
+
 - id: fukae
   name: 福江 / 福江改
 

--- a/docs/_data/ships/furutaka.yml
+++ b/docs/_data/ships/furutaka.yml
@@ -1,0 +1,12 @@
+
+- id: furutaka
+  name: 古鷹 / 古鷹改
+
+- id: furutaka_2
+  name: 古鷹改二
+
+- id: kako
+  name: 加古 / 加古改
+
+- id: kako_2
+  name: 加古改二

--- a/docs/_data/ships/hiyou.yml
+++ b/docs/_data/ships/hiyou.yml
@@ -1,0 +1,9 @@
+
+- id: hiyou
+  name: 飛鷹 / 飛鷹改
+
+- id: junyou
+  name: 隼鷹 / 隼鷹改
+
+- id: junyou_2
+  name: 隼鷹改二

--- a/docs/_data/ships/houshou.yml
+++ b/docs/_data/ships/houshou.yml
@@ -1,0 +1,3 @@
+
+- id: houshou
+  name: 鳳翔 / 鳳翔改

--- a/docs/_data/ships/kasugamaru.yml
+++ b/docs/_data/ships/kasugamaru.yml
@@ -1,0 +1,3 @@
+
+- id: kasugamaru
+  name: 春日丸

--- a/docs/_data/ships/mizuho.yml
+++ b/docs/_data/ships/mizuho.yml
@@ -1,0 +1,3 @@
+
+- id: mizuho
+  name: 瑞穂 / 瑞穂改

--- a/docs/_data/ships/myoukou.yml
+++ b/docs/_data/ships/myoukou.yml
@@ -1,0 +1,24 @@
+
+- id: myoukou
+  name: 妙高 / 妙高改
+
+- id: myoukou_2
+  name: 妙高改二
+
+- id: nachi
+  name: 那智 / 那智改
+
+- id: nachi_2
+  name: 那智改二
+
+- id: ashigara
+  name: 足柄 / 足柄改
+
+- id: ashigara_2
+  name: 足柄改二
+
+- id: haguro
+  name: 羽黒 / 羽黒改
+
+- id: haguro_2
+  name: 羽黒改二

--- a/docs/_data/ships/nisshin.yml
+++ b/docs/_data/ships/nisshin.yml
@@ -1,0 +1,6 @@
+
+- id: nisshin
+  name: 日清 / 日清改
+
+- id: nisshin_a
+  name: 日清甲

--- a/docs/_data/ships/northampton.yml
+++ b/docs/_data/ships/northampton.yml
@@ -1,0 +1,3 @@
+
+- id: houston
+  name: Houston / Houston改

--- a/docs/_data/ships/perth.yml
+++ b/docs/_data/ships/perth.yml
@@ -1,0 +1,3 @@
+
+- id: perth
+  name: Perth / Perth改

--- a/docs/_data/ships/repairship.yml
+++ b/docs/_data/ships/repairship.yml
@@ -1,0 +1,3 @@
+
+- id: akashi
+  name: 明石 / 明石改

--- a/docs/_data/ships/ryuujou.yml
+++ b/docs/_data/ships/ryuujou.yml
@@ -1,0 +1,6 @@
+
+- id: ryuujou
+  name: 龍驤 / 龍驤改
+
+- id: ryuujou_2
+  name: 龍驤改二

--- a/docs/_data/ships/submarinetender.yml
+++ b/docs/_data/ships/submarinetender.yml
@@ -1,0 +1,3 @@
+
+- id: taigei
+  name: 大鯨

--- a/docs/_data/ships/takao.yml
+++ b/docs/_data/ships/takao.yml
@@ -1,0 +1,6 @@
+
+- id: takao
+  name: 高雄 / 高雄改
+
+- id: atago
+  name: 愛宕 / 愛宕改

--- a/docs/_data/ships/tone.yml
+++ b/docs/_data/ships/tone.yml
@@ -1,0 +1,12 @@
+
+- id: tone
+  name: 利根 / 利根改
+
+- id: tone_2
+  name: 利根改二
+
+- id: chikuma
+  name: 筑摩 / 筑摩改
+
+- id: chikuma_2
+  name: 筑摩改二

--- a/docs/_data/ships/yuubari.yml
+++ b/docs/_data/ships/yuubari.yml
@@ -1,3 +1,12 @@
 
 - id: yuubari
   name: 夕張 / 夕張改
+
+- id: yuubari_2
+  name: 夕張改二
+
+- id: yuubari_2s
+  name: 夕張改二特
+
+- id: yuubari_2d
+  name: 夕張改二丁

--- a/docs/_data/ships/yuugumo.yml
+++ b/docs/_data/ships/yuugumo.yml
@@ -47,6 +47,8 @@
 - id: hayashimo
   name: 早霜 / 早霜改
 
+- id: akishimo
+  name: 秋霜 / 秋霜改
+
 - id: kiyoshimo
   name: 清霜 / 清霜改
-

--- a/docs/_data/ships/yuugumo.yml
+++ b/docs/_data/ships/yuugumo.yml
@@ -44,6 +44,9 @@
 - id: asashimo
   name: 朝霜 / 朝霜改
 
+- id: asashimo_2
+  name: 朝霜改二
+
 - id: hayashimo
   name: 早霜 / 早霜改
 

--- a/docs/_data/ships/zara.yml
+++ b/docs/_data/ships/zara.yml
@@ -1,0 +1,9 @@
+
+- id: zara
+  name: Zara / Zara改
+
+- id: zara_2
+  name: Zara due
+
+- id: pola
+  name: Pola / Pola改

--- a/docs/_data/stypes.yml
+++ b/docs/_data/stypes.yml
@@ -8,14 +8,23 @@
 - id: light_carrier
   name: 軽空母
 
-- id: light_cruiser
-  name: 軽巡洋艦・重雷装艦
+- id: heavy_cruiser
+  name: 重巡洋艦（派生含む）
 
-- id: training_cruiser
-  name: 練習巡洋艦
+- id: light_cruiser
+  name: 軽巡洋艦（派生含む）
 
 - id: destroyer
   name: 駆逐艦
 
 - id: escort
   name: 海防艦
+
+#- id: submarine
+#  name: 潜水艦・潜水母艦
+
+- id: seaplane_carrier
+  name: 水上機母艦
+
+#- id: other
+#  name: その他

--- a/docs/_data/stypes.yml
+++ b/docs/_data/stypes.yml
@@ -26,5 +26,8 @@
 - id: seaplane_carrier
   name: 水上機母艦
 
-#- id: other
-#  name: その他
+- id: amphibious_assault_ship
+  name: 揚陸艦
+
+- id: other
+  name: その他

--- a/docs/index.html
+++ b/docs/index.html
@@ -10,6 +10,7 @@
 	<meta name="description" content="「艦これ」における艦娘別装備ボーナスの一覧" />
 	<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
 	<script type="text/javascript" src="script.js"></script>
+	<script type="text/javascript" src="title.js"></script>
 	<link href="github.css" rel="stylesheet" />
 	<link href="https://fonts.googleapis.com/css?family=Muli:400,900|Noto+Sans+JP:400,900&amp;subset=japanese" rel="stylesheet">
 </head>
@@ -35,12 +36,16 @@
 			{% endfor %} {% endfor %}
 		</select>
 
-		<select class="children" name="ship_list" disabled>
+		<select class="children" name="ship_list" onChange="appearTitle()" disabled>
 			<option selected="custom_selected">--艦名選択--</option>
 			{% for stype in site.data.stypes %} {% for ctype in site.data.ctypes[stype.id] %} {% for ship in site.data.ships[ctype.id] %}
 			<option value="{{ ctype.id }}_{{ ship.id }}" data-val="{{ ctype.id }}">{{ ship.name }}</option>
 			{% endfor %} {% endfor %} {% endfor %}
 		</select>
+
+		<hr />
+
+		<h3 id="ship_name_title">{{ ship.name }}</h3>
 
 		<ul id="output"></ul>
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -45,7 +45,7 @@
 
 		<hr />
 
-		<h3 id="ship_name_title">{{ ship.name }}</h3>
+		<h3 id="ship_name_title"><a href="https://wikiwiki.jp/kancolle/{{ ship.name}}" target="blank">{{ ship.name }}</a></h3>
 
 		<ul id="output"></ul>
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -48,7 +48,7 @@
 
 		<dl>
 			<dt>これは何？</dt>
-			<dd>2019年7月時点における装備ボーナス（フィット砲）を、艦娘ごとに出力するページです。
+			<dd>2020年1月時点における装備ボーナス（フィット砲）を、艦娘ごとに出力するページです。
 				<a href="https://wikiwiki.jp/kancolle/">艦これ wiki</a> の情報を参考にしています。<br />
 				さまざまな呼び名がありますが、<a href="https://wikiwiki.jp/kancolle/装備#bonus">艦これ wiki</a> に習い「装備ボーナス」と呼ぶことにします。
 			</dd>
@@ -62,18 +62,18 @@
 			<dd>主砲と電探など、別の装備との組み合わせで得られる装備ボーナスです。単体ボーナスとは別に加算され、累積されません。</dd>
 		</dl>
 		<dl>
-			<dt>データに誤りを見つけた</dt>
+			<dt>データに誤りを見つけた、要望について報告</dt>
 			<dd><a href="https://kancolle.social/@nekogoro">作者</a>または<a href="https://github.com/nekogoro/kcfs/issues">Issues</a>まで</dd>
 		</dl>
 		<dl>
 				<dt>対応一覧</dt>
 				<dd>
-					艦娘：駆逐艦、軽巡洋艦、重雷装巡洋艦、練習巡洋艦、海防艦、航空母艦、軽空母、戦艦<br />
-					装備：小口径主砲、中口径主砲、大口径主砲、艦上機、その他（電探・ソナー）
+					艦娘：駆逐艦、軽巡洋艦（重雷装巡洋艦、練習巡洋艦、防空巡洋艦、兵装実験軽巡）、海防艦、航空母艦、軽空母、戦艦、重巡洋艦（航空巡洋艦）<br />
+					装備：小口径主砲、中口径主砲、大口径主砲、艦上機、その他（電探・ソナー・タービン）
 				</dd>
 		</dl>
 		<p>Special Thanks: <a href="https://wikiwiki.jp/kancolle/">艦これ wiki</a> & <a href="https://kancolle.social/">艦これ マストドン泊地</a></p>
-		<p>最終更新：2019/10/12 新規実装艦の追加</p>
+		<p>最終更新：2020/01/10 新規実装艦・装備の追加、重巡洋艦の追加、表記修正</p>
 	</div>
 	<footer>
 		<p>KanColle Experimental Dataset</p>

--- a/docs/index.html
+++ b/docs/index.html
@@ -67,6 +67,14 @@
 			<dd>主砲と電探など、別の装備との組み合わせで得られる装備ボーナスです。単体ボーナスとは別に加算され、累積されません。</dd>
 		</dl>
 		<dl>
+			<dt>「水上電探」とは</dt>
+			<dd>索敵+5以上の電探</dd>
+		</dl>
+		<dl>
+			<dt>「対空電探」とは</dt>
+			<dd><対空+1以上の電探dd>
+		</dl>
+		<dl>
 			<dt>データに誤りを見つけた、要望について報告</dt>
 			<dd><a href="https://kancolle.social/@nekogoro">作者</a>または<a href="https://github.com/nekogoro/kcfs/issues">Issues</a>まで</dd>
 		</dl>

--- a/docs/materials.json
+++ b/docs/materials.json
@@ -118,7 +118,7 @@
       {"text":"対空+6", "ship_class":"ayanami"},
       {"text":"対空+6", "ship_class":"akatsuki"}
     ]},
-    {"synergy":"＋水上電探＋対空電探", "items":[
+    {"synergy":"＋水上電探＋対空電探（または双方の条件を満たす電探）", "items":[
       {"text":"火力+3　雷装+1　対空+6　回避+2", "ship_class":"fubuki"},
       {"text":"火力+3　雷装+1　対空+6　回避+2", "ship_class":"ayanami"},
       {"text":"火力+3　雷装+1　対空+6　回避+2", "ship_class":"akatsuki"}
@@ -187,7 +187,7 @@
       {"text":"対空+5", "ship_class":"hatsuharu"},
       {"text":"対空+6", "ship_class":"shiratsuyu"}
     ]},
-    {"synergy":"＋GFCS Mk.37", "items":[
+    {"synergy":"＋水上電探＋対空電探（または双方の条件を満たす電探）", "items":[
       {"text":"火力+1　雷装+2　対空+5　回避+2", "ship_class":"ayanami"},
       {"text":"火力+1　雷装+2　対空+5　回避+2", "ship_class":"akatsuki"},
       {"text":"火力+1　雷装+2　対空+5　回避+2", "ship_class":"hatsuharu"},

--- a/docs/materials.json
+++ b/docs/materials.json
@@ -22,8 +22,13 @@
       {"text":"火力+3　雷装+7", "ship_class":"mutsuki"}
     ]}
   ]},
-  {"id":"229", "type":"小口径主砲", "title":"12.7cm単装高角砲(後期型)★7以上", "bonus":[
+  {"id":"229", "type":"小口径主砲", "title":"12.7cm単装高角砲(後期型)", "bonus":[
     {"synergy":"単体", "items":[
+      {"text":"火力+1　対空+1", "ship_class":"yuubari_yuubari_2"},
+      {"text":"火力+1　対空+1", "ship_class":"yuubari_yuubari_2s"},
+      {"text":"火力+1　対空+1", "ship_class":"yuubari_yuubari_2d"}
+    ]},
+    {"synergy":"単体(★7以上)", "items":[
       {"text":"火力+1　対空+1", "ship_class":"kamikaze"},
       {"text":"火力+1　対空+1", "ship_class":"mutsuki"},
       {"text":"火力+1　対空+1", "ship_class":"shimushu"},
@@ -34,6 +39,15 @@
       {"text":"火力+2　対空+2", "ship_class":"nagara_kinu_2"}
     ]},
     {"synergy":"＋水上電探", "items":[
+      {"text":"火力+1　回避+1", "ship_class":"yuubari_yuubari_2"},
+      {"text":"火力+1　回避+1", "ship_class":"yuubari_yuubari_2s"},
+      {"text":"火力+1　回避+1", "ship_class":"yuubari_yuubari_2d"}
+    ]},
+    {"synergy":"＋対空電探", "items":[
+      {"text":"対空+2　回避+2", "ship_class":"yuubari_yuubari_2"},
+      {"text":"対空+2　回避+2", "ship_class":"yuubari_yuubari_2s"},
+  ]},
+    {"synergy":"(★7以上)＋水上電探", "items":[
       {"text":"火力+2　回避+3", "ship_class":"kamikaze"},
       {"text":"火力+2　回避+3", "ship_class":"mutsuki"},
       {"text":"火力+1　回避+4", "ship_class":"shimushu"},
@@ -222,6 +236,7 @@
       {"text":"火力+3　回避+1", "ship_class":"yuugumo_makigumo_2"},
       {"text":"火力+3　回避+1", "ship_class":"yuugumo_kazagumo_2"},
       {"text":"火力+3　回避+1", "ship_class":"yuugumo_naganami_2"},
+      {"text":"火力+3　回避+1", "ship_class":"yuugumo_asashimo_2"},
       {"text":"火力+2　回避+1", "ship_class":"yuugumo"},
       {"text":"火力+2　回避+1", "ship_class":"shimakaze"},
       {"text":"火力+2　回避+1（累積不可）", "ship_class":"kagerou_kagerou_2"},
@@ -244,6 +259,7 @@
       {"text":"火力+3　雷装+4　回避+3", "ship_class":"yuugumo_makigumo_2"},
       {"text":"火力+3　雷装+4　回避+3", "ship_class":"yuugumo_kazagumo_2"},
       {"text":"火力+3　雷装+4　回避+3", "ship_class":"yuugumo_naganami_2"},
+      {"text":"火力+3　雷装+4　回避+3", "ship_class":"yuugumo_asashimo_2"},
       {"text":"火力+2　雷装+3　回避+1", "ship_class":"yuugumo"},
       {"text":"火力+1　雷装+3　回避+2", "ship_class":"shimakaze_shimakaze_1"}
     ]}
@@ -258,6 +274,7 @@
     {"synergy":"単体", "items":[
       {"text":"火力+2　対空+1　回避+1", "ship_class":"fletcher"},
       {"text":"火力+2　対空+1　回避+1", "ship_class":"johncbutler"},
+      {"text":"火力+1　対空+1　回避+1", "ship_class":"atlanta"},
       {"text":"火力+1", "ship_class":"kamikaze"},
       {"text":"火力+1", "ship_class":"mutsuki"},
       {"text":"火力+1", "ship_class":"fubuki"},
@@ -300,7 +317,7 @@
       {"text":"火力+3　雷装+2　回避+2", "ship_class":"aoba"}
     ]},
     {"synergy":"＋対空電探", "items":[
-      {"text":"対空+5　回避+2", "ship_class":"aoba"}
+      {"text":"対空+5　回避+2", "ship_class":"aoba_aoba"}
     ]}
   ]},
   {"id":"303", "type":"中口径主砲", "title":"Bofors15.2cm連装砲 Model1930", "bonus":[
@@ -321,9 +338,22 @@
   ]},
   {"id":"310", "type":"中口径主砲", "title":"14cm連装砲改", "bonus":[
     {"synergy":"単体", "items":[
+      {"text":"火力+4　対空+1　回避+2　対潜+1", "ship_class":"yuubari_yuubari_2"},
+      {"text":"火力+4　対空+1　回避+2　対潜+1", "ship_class":"yuubari_yuubari_2s"},
+      {"text":"火力+4　対空+1　回避+2　対潜+1", "ship_class":"yuubari_yuubari_2d"},
       {"text":"火力+2　対空+1　回避+1", "ship_class":"yuubari"},
       {"text":"火力+2　回避+1", "ship_class":"katori"},
       {"text":"火力+3　雷装+2　対空+1　回避+1", "ship_class":"nisshin"}
+    ]},
+    {"synergy":"単体(★8以上)", "items":[
+      {"text":"火力+5　雷装+1　対空+1　回避+2　対潜+1", "ship_class":"yuubari_yuubari_2"},
+      {"text":"火力+5　雷装+1　対空+1　回避+2　対潜+1", "ship_class":"yuubari_yuubari_2s"},
+      {"text":"火力+5　雷装+1　対空+1　回避+2　対潜+1", "ship_class":"yuubari_yuubari_2d"}
+    ]},
+    {"synergy":"＋水上電探", "items":[
+      {"text":"火力+3　雷装+2　回避+2", "ship_class":"yuubari_yuubari_2"},
+      {"text":"火力+3　雷装+2　回避+2", "ship_class":"yuubari_yuubari_2s"},
+      {"text":"火力+3　雷装+2　回避+2", "ship_class":"yuubari_yuubari_2d"}
     ]}
   ]},
   {"id":"340", "type":"中口径主砲", "title":"152mm／55 三連装速射砲", "bonus":[
@@ -335,6 +365,75 @@
     {"synergy":"単体", "items":[
       {"text":"火力+2　対空+1　回避+1", "ship_class":"ldsddabruzzi"},
       {"text":"火力+1　対空+1　回避+1", "ship_class":"gotland_gotland"}
+    ]}
+  ]},
+  {"id":"359", "type":"中口径主砲", "title":"6inch連装速射砲 Mk.XXI", "bonus":[
+    {"synergy":"単体", "items":[
+      {"text":"火力+2　対空+2　回避+1", "ship_class":"perth"},
+      {"text":"火力+2　対空+2　回避+1", "ship_class":"yuubari_yuubari_2"},
+      {"text":"火力+2　対空+2　回避+1", "ship_class":"yuubari_yuubari_2s"},
+      {"text":"火力+2　対空+2　回避+1", "ship_class":"yuubari_yuubari_2d"},
+      {"text":"火力+1　対空+1　回避+1", "ship_class":"yuubari"}
+    ]}
+  ]},
+  {"id":"356", "type":"中口径主砲", "title":"8inch三連装砲 Mk.9", "bonus":[
+    {"synergy":"単体", "items":[
+      {"text":"火力+2", "ship_class":"houston"},
+      {"text":"火力+1", "ship_class":"mogami"}
+    ]}
+  ]},
+  {"id":"357", "type":"中口径主砲", "title":"8inch三連装砲 Mk.9 mod.2", "bonus":[
+    {"synergy":"単体", "items":[
+      {"text":"火力+2", "ship_class":"houston"},
+      {"text":"火力+1", "ship_class":"mogami"}
+    ]}
+  ]},
+  {"id":"360", "type":"中口径主砲", "title":"Bofors 15cm連装速射砲 Mk.9 Model 1938", "bonus":[
+    {"synergy":"単体", "items":[
+      {"text":"火力+2　対空+2　回避+1", "ship_class":"deruyter"},
+      {"text":"火力+2　対空+1　回避+1", "ship_class":"gotland"},
+      {"text":"火力+1", "ship_class":"agano"}
+    ]}
+  ]},
+  {"id":"361", "type":"中口径主砲", "title":"Bofors 15cm連装速射砲 Mk.9改＋単装速射砲 Mk.10改 Model 1938", "bonus":[
+    {"synergy":"単体", "items":[
+      {"text":"火力+2　対空+2　回避+1", "ship_class":"deruyter"},
+      {"text":"火力+2　対空+1　回避+1", "ship_class":"gotland"},
+      {"text":"火力+1", "ship_class":"agano"}
+    ]}
+  ]},
+  {"id":"362", "type":"中口径主砲", "title":"5inch連装両用砲(集中配備)", "bonus":[
+    {"synergy":"単体", "items":[
+      {"text":"火力+1　対空+3　回避+2", "ship_class":"atlanta"},
+      {"text":"対空+1　回避+1", "ship_class":"houston"},
+      {"text":"対空+1　回避+1", "ship_class":"colorado"},
+      {"text":"対空-1　回避-2", "ship_class":"ooyodo"},
+      {"text":"対空-1　回避-2", "ship_class":"agano"},
+      {"text":"対空-1　回避-2", "ship_class":"deruyter"},
+      {"text":"火力-2　対空-1　回避-4", "ship_class":"gotland"},
+      {"text":"火力-2　対空-1　回避-4", "ship_class":"katori"},
+      {"text":"火力-3　対空-2　回避-6", "ship_class":"kuma"},
+      {"text":"火力-3　対空-2　回避-6", "ship_class":"nagara"},
+      {"text":"火力-3　対空-2　回避-6", "ship_class":"sendai"},
+      {"text":"火力-3　対空-3　回避-8", "ship_class":"tenryuu"},
+      {"text":"火力-3　対空-3　回避-8", "ship_class":"yuubari"}
+    ]}
+  ]},
+  {"id":"363", "type":"中口径主砲", "title":"GFCS Mk.37＋5inch連装両用砲(集中配備)", "bonus":[
+    {"synergy":"単体", "items":[
+      {"text":"火力+1　対空+3　回避+2", "ship_class":"atlanta"},
+      {"text":"対空+1　回避+1", "ship_class":"houston"},
+      {"text":"対空+1　回避+1", "ship_class":"colorado"},
+      {"text":"対空-1　回避-2", "ship_class":"ooyodo"},
+      {"text":"対空-1　回避-2", "ship_class":"agano"},
+      {"text":"対空-1　回避-2", "ship_class":"deruyter"},
+      {"text":"火力-2　対空-1　回避-4", "ship_class":"gotland"},
+      {"text":"火力-2　対空-1　回避-4", "ship_class":"katori"},
+      {"text":"火力-3　対空-2　回避-6", "ship_class":"kuma"},
+      {"text":"火力-3　対空-2　回避-6", "ship_class":"nagara"},
+      {"text":"火力-3　対空-2　回避-6", "ship_class":"sendai"},
+      {"text":"火力-3　対空-3　回避-8", "ship_class":"tenryuu"},
+      {"text":"火力-3　対空-3　回避-8", "ship_class":"yuubari"}
     ]}
   ]},
   {"id":"289", "type":"大口径主砲", "title":"35.6cm三連装砲改(ダズル迷彩仕様)", "bonus":[
@@ -493,6 +592,34 @@
       {"text":"火力+1", "ship_class":"nagato_nagato_1"},
       {"text":"火力+1", "ship_class":"nagato_mutsu_1"},
       {"text":"火力+1", "ship_class":"colorado"}
+    ]}
+  ]},
+  {"id":"019", "type":"艦上機", "title":"九六式艦戦", "bonus":[
+    {"synergy":"単体", "items":[
+      {"text":"火力+1　対空+1　対潜+1　回避+2", "ship_class":"houshou"},
+      {"text":"火力+1　対空+1　対潜+2　回避+1", "ship_class":"kasugamaru"},
+      {"text":"火力+1　対空+1　対潜+2　回避+1", "ship_class":"taiyou"},
+      {"text":"対空+1　回避+1", "ship_class":"ryuujou"},
+      {"text":"対空+1　回避+1", "ship_class":"ryuuhou"},
+      {"text":"対空+1　回避+1", "ship_class":"shouhou"},
+      {"text":"対空+1　回避+1", "ship_class":"hiyou"},
+      {"text":"対空+1　回避+1", "ship_class":"chitose-v"},
+      {"text":"対空+1　回避+1", "ship_class":"mogami-v"},
+      {"text":"対空+1　回避+1", "ship_class":"casablanca}
+    ]}
+  ]},
+  {"id":"228", "type":"艦上機", "title":"九六式艦戦改", "bonus":[
+    {"synergy":"単体", "items":[
+      {"text":"火力+1　対空+3　対潜+2　回避+3", "ship_class":"houshou"},
+      {"text":"火力+1　対空+2　対潜+4　回避+2", "ship_class":"kasugamaru"},
+      {"text":"火力+1　対空+2　対潜+4　回避+2", "ship_class":"taiyou"},
+      {"text":"対空+1　対潜+2　回避+1", "ship_class":"ryuujou"},
+      {"text":"対空+1　対潜+2　回避+1", "ship_class":"ryuuhou"},
+      {"text":"対空+1　対潜+2　回避+1", "ship_class":"shouhou"},
+      {"text":"対空+1　対潜+2　回避+1", "ship_class":"hiyou"},
+      {"text":"対空+1　対潜+2　回避+1", "ship_class":"chitose-v"},
+      {"text":"対空+1　対潜+2　回避+1", "ship_class":"mogami-v"},
+      {"text":"対空+1　対潜+2　回避+1", "ship_class":"casablanca}
     ]}
   ]},
   {"id":"335", "type":"艦上機", "title":"烈風改(試製艦載型)", "bonus":[
@@ -798,14 +925,14 @@
   ]},
   {"id":"061", "type":"艦上機", "title":"二式艦上偵察機", "bonus":[
     {"synergy":"★0(累積不可)", "items":[
-      {"text":"火力+3　回避+2　装甲+1　射程1段階延長", "ship_class":"ise_ise_2"},
-      {"text":"火力+3　回避+3　装甲+3　射程1段階延長", "ship_class":"ise_hyuuga_2"},
       {"text":"射程1段階延長", "ship_class":"souryuu_souryuu_2"},
       {"text":"射程1段階延長", "ship_class":"hiryuu_hiryuu_2"}
     ]},
-    {"synergy":"★1(累積不可)", "items":[
+    {"synergy":"★0～1(累積不可)", "items"[
       {"text":"火力+3　回避+2　装甲+1　射程1段階延長", "ship_class":"ise_ise_2"},
-      {"text":"火力+3　回避+3　装甲+3　射程1段階延長", "ship_class":"ise_hyuuga_2"},
+      {"text":"火力+3　回避+3　装甲+3　射程1段階延長", "ship_class":"ise_hyuuga_2"}
+    ]},
+    {"synergy":"★1(累積不可)", "items":[
       {"text":"火力+3　索敵+3　射程1段階延長", "ship_class":"souryuu_souryuu_2"},
       {"text":"火力+3　索敵+3", "ship_class":"souryuu"},
       {"text":"火力+2　索敵+2　射程1段階延長", "ship_class":"hiryuu_hiryuu_2"},
@@ -814,7 +941,7 @@
       {"text":"火力+1　索敵+1", "ship_class":"mogami-v_suzuya_v2"},
       {"text":"火力+1　索敵+1", "ship_class":"mogami-v_kumano_v2"}
     ]},
-    {"synergy":"★2(累積不可)", "items":[
+    {"synergy":"★2～3(累積不可)", "items"[
       {"text":"火力+3　回避+2　装甲+1　索敵+1　射程1段階延長", "ship_class":"ise_ise_2"},
       {"text":"火力+3　回避+3　装甲+3　索敵+1　射程1段階延長", "ship_class":"ise_hyuuga_2"},
       {"text":"火力+3　索敵+4　射程1段階延長", "ship_class":"souryuu_souryuu_2"},
@@ -835,30 +962,9 @@
       {"text":"索敵+1", "ship_class":"essex"},
       {"text":"索敵+1", "ship_class":"arkroyal"}
     ]},
-    {"synergy":"★3(累積不可)", "items":[
-      {"text":"火力+3　回避+2　装甲+1　索敵+1　射程1段階延長", "ship_class":"ise_ise_2"},
-      {"text":"火力+3　回避+3　装甲+3　索敵+1　射程1段階延長", "ship_class":"ise_hyuuga_2"},
-      {"text":"火力+3　索敵+4　射程1段階延長", "ship_class":"souryuu_souryuu_2"},
-      {"text":"火力+3　索敵+4", "ship_class":"souryuu"},
-      {"text":"火力+2　索敵+3　射程1段階延長", "ship_class":"hiryuu_hiryuu_2"},
-      {"text":"火力+2　索敵+3", "ship_class":"hiryuu"},
-      {"text":"火力+1　索敵+2", "ship_class":"shouhou_zuihou_2b"},
-      {"text":"火力+1　索敵+2", "ship_class":"mogami-v_suzuya_v2"},
-      {"text":"火力+1　索敵+2", "ship_class":"mogami-v_kumano_v2"},
-      {"text":"索敵+1", "ship_class":"akagi"},
-      {"text":"索敵+1", "ship_class":"kaga"},
-      {"text":"索敵+1", "ship_class":"shoukaku"},
-      {"text":"索敵+1", "ship_class":"unryuu"},
-      {"text":"索敵+1", "ship_class":"taihou"},
-      {"text":"索敵+1", "ship_class":"grafzeppelin"},
-      {"text":"索敵+1", "ship_class":"aquila"},
-      {"text":"索敵+1", "ship_class":"lexington"},
-      {"text":"索敵+1", "ship_class":"essex"},
-      {"text":"索敵+1", "ship_class":"arkroyal"}
-    ]},
-    {"synergy":"★4(累積不可)", "items":[
+    {"synergy":"★4～5(累積不可)", "items"[
       {"text":"火力+4　回避+2　装甲+1　索敵+1　射程1段階延長", "ship_class":"ise_ise_2"},
-      {"text":"火力+4　回避+3　装甲+3　索敵+1　射程1段階延長", "ship_class":"ise_hyuuga_2"},
+      {"text":"火力+4　回避+3　装甲+3　索敵+1　射程1段階延長", "ship_class":"ise_hyuuga_2"}
       {"text":"火力+4　索敵+4　射程1段階延長", "ship_class":"souryuu_souryuu_2"},
       {"text":"火力+4　索敵+4", "ship_class":"souryuu"},
       {"text":"火力+3　索敵+3　射程1段階延長", "ship_class":"hiryuu_hiryuu_2"},
@@ -877,95 +983,11 @@
       {"text":"火力+1　索敵+1", "ship_class":"essex"},
       {"text":"火力+1　索敵+1", "ship_class":"arkroyal"}
     ]},
-    {"synergy":"★5(累積不可)", "items":[
-      {"text":"火力+4　回避+2　装甲+1　索敵+1　射程1段階延長", "ship_class":"ise_ise_2"},
-      {"text":"火力+4　回避+3　装甲+3　索敵+1　射程1段階延長", "ship_class":"ise_hyuuga_2"},
-      {"text":"火力+4　索敵+4　射程1段階延長", "ship_class":"souryuu_souryuu_2"},
-      {"text":"火力+4　索敵+4", "ship_class":"souryuu"},
-      {"text":"火力+3　索敵+3　射程1段階延長", "ship_class":"hiryuu_hiryuu_2"},
-      {"text":"火力+3　索敵+3", "ship_class":"hiryuu"},
-      {"text":"火力+2　索敵+2", "ship_class":"shouhou_zuihou_2b"},
-      {"text":"火力+2　索敵+2", "ship_class":"mogami-v_suzuya_v2"},
-      {"text":"火力+2　索敵+2", "ship_class":"mogami-v_kumano_v2"},
-      {"text":"火力+1　索敵+1", "ship_class":"akagi"},
-      {"text":"火力+1　索敵+1", "ship_class":"kaga"},
-      {"text":"火力+1　索敵+1", "ship_class":"shoukaku"},
-      {"text":"火力+1　索敵+1", "ship_class":"unryuu"},
-      {"text":"火力+1　索敵+1", "ship_class":"taihou"},
-      {"text":"火力+1　索敵+1", "ship_class":"grafzeppelin"},
-      {"text":"火力+1　索敵+1", "ship_class":"aquila"},
-      {"text":"火力+1　索敵+1", "ship_class":"lexington"},
-      {"text":"火力+1　索敵+1", "ship_class":"essex"},
-      {"text":"火力+1　索敵+1", "ship_class":"arkroyal"}
-    ]},
-    {"synergy":"★6(累積不可)", "items":[
+    {"synergy":"★6～9(累積不可)", "items"[
       {"text":"火力+4　回避+2　装甲+1　索敵+2　射程1段階延長", "ship_class":"ise_ise_2"},
       {"text":"火力+4　回避+3　装甲+3　索敵+2　射程1段階延長", "ship_class":"ise_hyuuga_2"},
       {"text":"火力+4　索敵+5　射程1段階延長", "ship_class":"souryuu_souryuu_2"},
       {"text":"火力+4　索敵+5", "ship_class":"souryuu"},
-      {"text":"火力+3　索敵+4　射程1段階延長", "ship_class":"hiryuu_hiryuu_2"},
-      {"text":"火力+3　索敵+4", "ship_class":"hiryuu"},
-      {"text":"火力+2　索敵+3", "ship_class":"shouhou_zuihou_2b"},
-      {"text":"火力+2　索敵+3", "ship_class":"mogami-v_suzuya_v2"},
-      {"text":"火力+2　索敵+3", "ship_class":"mogami-v_kumano_v2"},
-      {"text":"火力+1　索敵+2", "ship_class":"akagi"},
-      {"text":"火力+1　索敵+2", "ship_class":"kaga"},
-      {"text":"火力+1　索敵+2", "ship_class":"shoukaku"},
-      {"text":"火力+1　索敵+2", "ship_class":"unryuu"},
-      {"text":"火力+1　索敵+2", "ship_class":"taihou"},
-      {"text":"火力+1　索敵+2", "ship_class":"grafzeppelin"},
-      {"text":"火力+1　索敵+2", "ship_class":"aquila"},
-      {"text":"火力+1　索敵+2", "ship_class":"lexington"},
-      {"text":"火力+1　索敵+2", "ship_class":"essex"},
-      {"text":"火力+1　索敵+2", "ship_class":"arkroyal"}
-    ]},
-    {"synergy":"★7(累積不可)", "items":[
-      {"text":"火力+4　回避+2　装甲+1　索敵+2　射程1段階延長", "ship_class":"ise_ise_2"},
-      {"text":"火力+4　回避+3　装甲+3　索敵+2　射程1段階延長", "ship_class":"ise_hyuuga_2"},
-      {"text":"火力+4　索敵+5　射程1段階延長", "ship_class":"souryuu_souryuu_2"},
-      {"text":"火力+4　索敵+5", "ship_class":"souryuu"},
-      {"text":"火力+3　索敵+4　射程1段階延長", "ship_class":"hiryuu_hiryuu_2"},
-      {"text":"火力+3　索敵+4", "ship_class":"hiryuu"},
-      {"text":"火力+2　索敵+3", "ship_class":"shouhou_zuihou_2b"},
-      {"text":"火力+2　索敵+3", "ship_class":"mogami-v_suzuya_v2"},
-      {"text":"火力+2　索敵+3", "ship_class":"mogami-v_kumano_v2"},
-      {"text":"火力+1　索敵+2", "ship_class":"akagi"},
-      {"text":"火力+1　索敵+2", "ship_class":"kaga"},
-      {"text":"火力+1　索敵+2", "ship_class":"shoukaku"},
-      {"text":"火力+1　索敵+2", "ship_class":"unryuu"},
-      {"text":"火力+1　索敵+2", "ship_class":"taihou"},
-      {"text":"火力+1　索敵+2", "ship_class":"grafzeppelin"},
-      {"text":"火力+1　索敵+2", "ship_class":"aquila"},
-      {"text":"火力+1　索敵+2", "ship_class":"lexington"},
-      {"text":"火力+1　索敵+2", "ship_class":"essex"},
-      {"text":"火力+1　索敵+2", "ship_class":"arkroyal"}
-    ]},
-    {"synergy":"★8(累積不可)", "items":[
-      {"text":"火力+4　回避+2　装甲+1　索敵+2　射程1段階延長", "ship_class":"ise_ise_2"},
-      {"text":"火力+4　回避+3　装甲+3　索敵+2　射程1段階延長", "ship_class":"ise_hyuuga_2"},
-      {"text":"火力+5　索敵+6　射程1段階延長", "ship_class":"souryuu_souryuu_2"},
-      {"text":"火力+5　索敵+6", "ship_class":"souryuu"},
-      {"text":"火力+3　索敵+4　射程1段階延長", "ship_class":"hiryuu_hiryuu_2"},
-      {"text":"火力+3　索敵+4", "ship_class":"hiryuu"},
-      {"text":"火力+2　索敵+3", "ship_class":"shouhou_zuihou_2b"},
-      {"text":"火力+2　索敵+3", "ship_class":"mogami-v_suzuya_v2"},
-      {"text":"火力+2　索敵+3", "ship_class":"mogami-v_kumano_v2"},
-      {"text":"火力+1　索敵+2", "ship_class":"akagi"},
-      {"text":"火力+1　索敵+2", "ship_class":"kaga"},
-      {"text":"火力+1　索敵+2", "ship_class":"shoukaku"},
-      {"text":"火力+1　索敵+2", "ship_class":"unryuu"},
-      {"text":"火力+1　索敵+2", "ship_class":"taihou"},
-      {"text":"火力+1　索敵+2", "ship_class":"grafzeppelin"},
-      {"text":"火力+1　索敵+2", "ship_class":"aquila"},
-      {"text":"火力+1　索敵+2", "ship_class":"lexington"},
-      {"text":"火力+1　索敵+2", "ship_class":"essex"},
-      {"text":"火力+1　索敵+2", "ship_class":"arkroyal"}
-    ]},
-    {"synergy":"★9(累積不可)", "items":[
-      {"text":"火力+4　回避+2　装甲+1　索敵+2　射程1段階延長", "ship_class":"ise_ise_2"},
-      {"text":"火力+4　回避+3　装甲+3　索敵+2　射程1段階延長", "ship_class":"ise_hyuuga_2"},
-      {"text":"火力+5　索敵+6　射程1段階延長", "ship_class":"souryuu_souryuu_2"},
-      {"text":"火力+5　索敵+6", "ship_class":"souryuu"},
       {"text":"火力+3　索敵+4　射程1段階延長", "ship_class":"hiryuu_hiryuu_2"},
       {"text":"火力+3　索敵+4", "ship_class":"hiryuu"},
       {"text":"火力+2　索敵+3", "ship_class":"shouhou_zuihou_2b"},
@@ -1004,6 +1026,12 @@
       {"text":"火力+2　索敵+3", "ship_class":"arkroyal"}
     ]}
   ]},
+  {"id":"033", "type":"その他", "title":"改良型艦本式タービン", "bonus":[
+    {"synergy":"単体(累積不可)", "items":[
+      {"text":"速力:高速(缶不要)", "ship_class":"johncbutler"},
+      {"text":"速力:高速(缶不要)", "ship_class":"yuubari_yuubari_2s"}
+    ]}
+  ]},
   {"id":"106", "type":"その他", "title":"13号対空電探改", "bonus":[
     {"synergy":"単体", "items":[
       {"text":"火力+1　対空+2　回避+3　装甲+1", "ship_class":"ayanami_ushio_2"},
@@ -1038,18 +1066,22 @@
       {"text":"火力+1　対空+1　回避+1", "ship_class":"essex"},
       {"text":"火力+1　対空+1　回避+1", "ship_class":"casablanca"},
       {"text":"火力+1　対空+1　回避+1", "ship_class":"fletcher"},
-      {"text":"火力+1　対空+1　回避+1", "ship_class":"johncbutler"}
+      {"text":"火力+1　対空+1　回避+1", "ship_class":"johncbutler"},
+      {"text":"火力+1　対空+1　回避+1", "ship_class":"houston"},
+      {"text":"火力+1　対空+1　回避+1", "ship_class":"atlanta"}
     ]}
   ]},
   {"id":"315", "type":"その他", "title":"SG レーダー(初期型)", "bonus":[
     {"synergy":"単体", "items":[
-      {"text":"火力+3　回避+3　索敵+4", "ship_class":"fletcher"},
-      {"text":"火力+3　回避+3　索敵+4", "ship_class":"johncbutler"},
+      {"text":"火力+3　回避+3　索敵+4　射程:長", "ship_class":"fletcher"},
+      {"text":"火力+3　回避+3　索敵+4　射程:長", "ship_class":"johncbutler"},
       {"text":"火力+2　回避+3　索敵+4", "ship_class":"colorado"},
       {"text":"火力+2　回避+3　索敵+4", "ship_class":"iowa"},
       {"text":"火力+2　回避+3　索敵+4", "ship_class":"lexington"},
       {"text":"火力+2　回避+3　索敵+4", "ship_class":"essex"},
-      {"text":"火力+2　回避+3　索敵+4", "ship_class":"casablanca"}
+      {"text":"火力+2　回避+3　索敵+4", "ship_class":"casablanca"},
+      {"text":"火力+2　回避+3　索敵+4", "ship_class":"houston"},
+      {"text":"火力+2　回避+3　索敵+4", "ship_class":"atlanta"}
     ]}
   ]},
   {"id":"047", "type":"その他", "title":"三式水中探信儀", "bonus":[
@@ -1070,6 +1102,17 @@
       {"text":"回避+2　対潜+2", "ship_class":"kagerou_hamakaze"},
       {"text":"回避+2　対潜+2", "ship_class":"kagerou_hamakaze_b1"},
       {"text":"回避+2　対潜+2", "ship_class":"yuugumo_kishinami"}
+    ]}
+  ]},
+  {"id":"149", "type":"その他", "title":"四式水中探信儀", "bonus":[
+    {"synergy":"単体(累積不可)", "items":[
+      {"text":"回避+2　対潜+1", "ship_class":"akiduki"},
+      {"text":"回避+3　対潜+1", "ship_class":"nagara_isuzu_2"},
+      {"text":"回避+3　対潜+1", "ship_class":"nagara_yura_2"},
+      {"text":"回避+3　対潜+1", "ship_class":"sendai_naka_2"},
+      {"text":"回避+3　対潜+1", "ship_class":"yuubari_yuubari_2"},
+      {"text":"回避+3　対潜+1", "ship_class":"yuubari_yuubari_2s"},
+      {"text":"回避+5　対潜+3", "ship_class":"yuubari_yuubari_2d"}
     ]}
   ]},
   {"id":"035", "type":"その他", "title":"三式弾", "bonus":[

--- a/docs/title.js
+++ b/docs/title.js
@@ -1,0 +1,12 @@
+var list = document.getElementById("ship_list");
+var title = document.getElementById("ship_name_title");
+title.style.display = "none";
+
+function appearTitle() {
+  var index = list.selectedIndex;
+  if (!list.disabled && title.style.display == "none" && index > 0) {
+    title.style.display = "block";
+  } else {
+    title.style.display = "none";
+  }
+}


### PR DESCRIPTION
- [x] 艦種の調整
    - [x] 練習巡洋艦を軽巡洋艦に統合
- [x] 艦種の追加
    - [x] 重巡
    - [x] 水上機母艦
    - [x] その他
- [x] 艦娘の追加
    - [x] 重巡系
        - [x] Houston
    - [x] 軽巡系
        - [x] De Ruyter
        - [x] Perth
        - [x] Atlanta
        - [x] 夕張改二
    - [x] 軽空母
    - [x] 駆逐艦
        - [x] 秋霜
        - [x] 朝霜改二
    - [x] 海防艦
        - [x] 平戸
    - [x] 水上機母艦
    - [x] その他
        - [x] 神州丸
- [x] [materials.json](https://github.com/nekogoro/kcfs/blob/master/docs/materials.json) の更新
    - [x] 新規実装装備の追加
    - [x] 今回追加した艦娘に関する装備ボーナスの更新
        - [x] 九六式艦戦
        - [x] 九六式艦戦改
        - [ ] 彩雲
        - [x] 二式艦上偵察機
            - 春日丸/大鷹/大鷹改/神鷹/神鷹改 は装備不可
        - [x] Bofors 系
        - [x] 米軍電探
    - [x] 表記の修正
        - [ ] 水上・対空双方を満たす電探に関する表記
        - [x] SG レーダー(初期型) の射程長
- [ ] index.html の変更
    - [x] 艦娘名表示
        - [x] wikiwiki へのリンク追加
    - [ ] 更新履歴を release でやる